### PR TITLE
Added python 2.6+ compatibility

### DIFF
--- a/modp-test.py
+++ b/modp-test.py
@@ -3,8 +3,9 @@ from test import test
 
 mod7 = IntegersModP(7)
 
+test(mod7(5), mod7(5)) # Sanity check
 test(mod7(5), 1 / mod7(3))
-test(mod7(1), mod7(3) * mod7(5))
+test(mod7(1), mod7(3) * mod7(5)) 
 test(mod7(3), mod7(3) * 1)
 test(mod7(2), mod7(5) + mod7(4))
 

--- a/modp.py
+++ b/modp.py
@@ -37,6 +37,10 @@ def IntegersModP(p):
          return isinstance(other, IntegerModP) and self.n == other.n
 
       @typecheck
+      def __ne__(self, other):
+         return isinstance(other, IntegerModP) is False or self.n != other.n
+
+      @typecheck
       def __divmod__(self, divisor):
          q,r = divmod(self.n, divisor.n)
          return (IntegerModP(q), IntegerModP(r))

--- a/polynomial-test.py
+++ b/polynomial-test.py
@@ -1,3 +1,4 @@
+from __future__ import division
 from test import test
 from fractions import Fraction
 from polynomial import *

--- a/polynomial.py
+++ b/polynomial.py
@@ -1,4 +1,7 @@
-import itertools
+try:
+    from itertools import zip_longest
+except ImportError:
+    from itertools import izip_longest as zip_longest
 import fractions
 
 from numbertype import *
@@ -22,7 +25,10 @@ def polynomialsOver(field=fractions.Fraction):
 
    class Polynomial(DomainElement):
       operatorPrecedence = 2
-      factory = lambda L: Polynomial([field(x) for x in L])
+
+      @classmethod
+      def factory(cls, L):
+         return Polynomial([cls.field(x) for x in L])
 
       def __init__(self, c):
          if type(c) is Polynomial:
@@ -61,10 +67,13 @@ def polynomialsOver(field=fractions.Fraction):
       def __eq__(self, other):
          return self.degree() == other.degree() and all([x==y for (x,y) in zip(self, other)])
 
+      @typecheck
+      def __ne__(self, other):
+          return self.degree() != other.degree() or any([x!=y for (x,y) in zip(self, other)])
 
       @typecheck
       def __add__(self, other):
-         newCoefficients = [sum(x) for x in itertools.zip_longest(self, other, fillvalue=self.field(0))]
+         newCoefficients = [sum(x) for x in zip_longest(self, other, fillvalue=self.field(0))]
          return Polynomial(newCoefficients)
 
 


### PR DESCRIPTION
I made a few changes so that the code runs and the tests pass on python 2.6+. I've tested on python 2.6, 2.7, 3.2.

Most notably, an explicit **ne** (!=) method was required for IntegerModP and Polynomial and the factory lambda on Polynomial had to be changed to a class method.

I hope you don't mind the changes.
